### PR TITLE
Removed PHP end tag

### DIFF
--- a/php.mustache
+++ b/php.mustache
@@ -80,5 +80,3 @@ if(!$resp) {
 
 // Close request to clear up some resources
 curl_close($ch);
-
-?>


### PR DESCRIPTION
As PHP end tags are obsolete for PHP-only files, it's safe to omit them.

> If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file. This prevents accidental whitespace or new lines being added after the PHP closing tag, which may cause unwanted effects because PHP will start output buffering when there is no intention from the programmer to send any output at that point in the script.
> – [The PHP.net Manual](http://php.net/manual/en/language.basic-syntax.phptags.php)
